### PR TITLE
use global add instead of --global option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Encode Markdown to Scrapbox.io style text
 
 ### CLI
 
-- `% yarn install -g md2sb`
+- `% yarn global add md2sb`
   - I recommend yarn but you can use `npm`.
 - `% md2sb hoge.md > hoge.txt`
   - You can pass filename as option


### PR DESCRIPTION
yarn 1.2.1 で以下のエラーが出たため、`--global` オプションをやめて `global add ` を使うようにREADMEを修正したPRを作成しました。

```
$ yarn install -g md2sb
yarn install v1.2.1
info No lockfile found.
error `--global` has been deprecated. Please run "yarn global add md2sb" instead.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```